### PR TITLE
Add APRARX to tocalls.yaml

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -842,8 +842,8 @@ tocalls:
    model: Balloon tracker
    class: tracker
 
-- tocall: APRARX
-  vendor: Open Source
-  model: radiosonde_auto_rx
-  class: software
-  os: Linux/Unix
+ - tocall: APRARX
+   vendor: Open Source
+   model: radiosonde_auto_rx
+   class: software
+   os: Linux/Unix

--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -842,3 +842,8 @@ tocalls:
    model: Balloon tracker
    class: tracker
 
+- tocall: APRARX
+  vendor: Open Source
+  model: radiosonde_auto_rx
+  class: software
+  os: Linux/Unix


### PR DESCRIPTION
As requested, a pull request to add the APRARX (radiosonde_auto_rx) entry into tocalls.yaml, for use on aprs.fi and other services.

I've attempted to match the other entries, hopefully all is OK!