### PR TITLE
Added APQTHx for QTH.app

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -667,6 +667,14 @@ tocalls:
    model: KetaiTracker
    class: tracker
 
+ - tocall: APQTH?
+   vendor: Weston Bustraan, W8WJB
+   model: QTH.app
+   class: software
+   os: macOS
+   features:
+     - messaging
+
  - tocall: APR8??
    vendor: Bob Bruninga, WB4APR
    model: APRSdos


### PR DESCRIPTION
Added the TOCALL for QTH.app.

QTH.app does use the aprs-deviceid JSON data, but I will wait until it has a proper homepage URL to add it to "Libraries and applications using this database" in README.md