### PR TITLE
Added APQTHx for QTH.app

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -667,6 +667,14 @@ tocalls:
    model: KetaiTracker
    class: tracker
 
+ - tocall: APQTH?
+   vendor: Weston Bustraan, W8WJB
+   model: QTH.app
+   class: software
+   os: macOS
+   features:
+     - messaging
+
  - tocall: APR8??
    vendor: Bob Bruninga, WB4APR
    model: APRSdos


### PR DESCRIPTION
Trying again, since I don't think my comments on #26 were read after it was closed.

I did contact Bob like you requested (prior to creating pull request #26, actually) and APQTHx is the ToCall that *he* suggested and assigned. My proposal was actually APMQxx, specifically to avoid the existing earthquake assignment, like you mentioned.

However, his response was:

> I don’t know that Earthquake data is being used.
>
> So, why not use APQTHx?
>
> Bob

I forwarded the full email exchange, but I assume that it ended up in your spam box.
