### PR TITLE
Update tocalls.yaml

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -52,6 +52,10 @@ classes:
  - class: satellite
    shown: Satellite
    description: Satellite-based station
+   
+ - class: AoT
+  shown: APRS of Things
+  description: Autonomous APRS/LoRa MCU-driven Device (Beaconing/Telemetry/Remote-Control/Reporting/Tracking)
 
 #
 # mic-e device identifier index for new-style 2-character device
@@ -860,6 +864,12 @@ tocalls:
    vendor: F5OPV, SFCP_LABS
    model: LoRa/APRS Gateway
    class: digi
+   os: embedded
+
+ - tocall: APSFTL
+   vendor: F5OPV, SFCP_LABS
+   model: LoRa/APRS Telemetry Reporter
+   class: AoT
    os: embedded
 
  - tocall: APTT*


### PR DESCRIPTION
Hi Hessu,

would it be possible to add a new class to the tocalls list: AoT class, relative to APRS of Things, mcu-driven devices for beaconing, telemetry, remote controlers, reporters... objects?
The aprs equivalent of IoT but specifically for ham radio operators dealing with making of mcu ham stuff.

Any project about creation of new 'tech' icons in the aprs symbols list? (missing here icons with all my APRS objects hi !)
As coloured symbols 1 to 9 are not used in the alternate symbols table, it would be fine to get possibility of using color icon of primary table with alternate letters A-Z giving by this way numerous different new symbols.

Thanks in advance for answer Hessu.

PS Request of a new class of telemetry devices: APSFTL 

73 de F5OPV Pierre