### PR TITLE
Add APE2Ax, APCNxx, APN2xx, APMPAD, as seen in tocalls.txt

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -215,6 +215,10 @@ tocalls:
  - tocall: APCLUB
    model: Brazil APRS network
 
+ - tocall: APCN??
+   vendor: DG5OAW
+   model: carNET
+
  - tocall: APCSMS
    vendor: USNA
    model: Cosmos
@@ -249,6 +253,12 @@ tocalls:
    model: D-Star APDPRS
    class: dstar
 
+ - tocall: APE2A?
+   vendor: NoseyNick, VA3NNW
+   model: Email-2-APRS gateway
+   class: software
+   os: Linux/Unix
+
  - tocall: APERS?
    vendor: Jason, KG7YKZ
    model: Runner tracking
@@ -268,6 +278,10 @@ tocalls:
    vendor: WB8ELK
    model: Balloon tracker
    class: tracker
+
+ - tocall: APN2??
+   vendor: VE4KLM
+   model: NOSaprs for JNOS 2.0
 
  - tocall: APNK01
    vendor: Kenwood
@@ -388,6 +402,10 @@ tocalls:
    vendor: Microsat
    os: embedded
    model: WX3in1 Plus 2.0
+
+ - tocall: APMPAD
+   vendor: DF1JSL
+   model: WXBot clone and extension
 
  - tocall: APMQ??
    vendor: WB2OSZ


### PR DESCRIPTION
Slightly selfishly adding my `APE2A?`, but whilst I'm there, a few other recent ones as seen in http://aprs.org/aprs11/tocalls.txt too.

LMK if there's anything I've missed. `APCN??`, `APN2??`, `APMPAD` are **not** mine, so a little guesswork involved.

LMK if I should update the `generated/*` - the diffs looked CONSIDERABLY more than just these 4, perhaps random / different sort order?

~Speaking of which, is tocalls.yaml supposed to be sorted? It's kinda not quite, or at least not by `tocall:` ?~  (never mind, I see #16)