### PR TITLE
Icom updates

### DIFF
--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -215,6 +215,10 @@ tocalls:
  - tocall: APCLUB
    model: Brazil APRS network
 
+ - tocall: APCN??
+   vendor: DG5OAW
+   model: carNET
+
  - tocall: APCSMS
    vendor: USNA
    model: Cosmos
@@ -249,6 +253,12 @@ tocalls:
    model: D-Star APDPRS
    class: dstar
 
+ - tocall: APE2A?
+   vendor: NoseyNick, VA3NNW
+   model: Email-2-APRS gateway
+   class: software
+   os: Linux/Unix
+
  - tocall: APERS?
    vendor: Jason, KG7YKZ
    model: Runner tracking
@@ -268,6 +278,10 @@ tocalls:
    vendor: WB8ELK
    model: Balloon tracker
    class: tracker
+
+ - tocall: APN2??
+   vendor: VE4KLM
+   model: NOSaprs for JNOS 2.0
 
  - tocall: APNK01
    vendor: Kenwood
@@ -388,6 +402,10 @@ tocalls:
    vendor: Microsat
    os: embedded
    model: WX3in1 Plus 2.0
+
+ - tocall: APMPAD
+   vendor: DF1JSL
+   model: WXBot clone and extension
 
  - tocall: APMQ??
    vendor: WB2OSZ

--- a/tocalls.yaml
+++ b/tocalls.yaml
@@ -653,6 +653,56 @@ tocalls:
    model: unknown
    class: dstar
 
+ - tocall: API282
+   vendor: Icom
+   model: IC-2820
+   class: dstar
+
+ - tocall: API31
+   vendor: Icom
+   model: IC-31
+   class: dstar
+
+ - tocall: API410
+   vendor: Icom
+   model: IC-4100
+   class: dstar
+
+ - tocall: API51
+   vendor: Icom
+   model: IC-51
+   class: dstar
+
+ - tocall: API510
+   vendor: Icom
+   model: IC-5100
+   class: dstar
+
+ - tocall: API710
+   vendor: Icom
+   model: IC-7100
+   class: dstar
+
+ - tocall: API80
+   vendor: Icom
+   model: IC-80
+   class: dstar
+
+ - tocall: API880
+   vendor: Icom
+   model: IC-880
+   class: dstar
+
+ - tocall: API910
+   vendor: Icom
+   model: IC-9100
+   class: dstar
+
+ - tocall: API92
+   vendor: Icom
+   model: IC-92
+   class: dstar
+
  - tocall: API970
    vendor: Icom
    model: IC-9700


### PR DESCRIPTION
Somewhat assuming https://groups.google.com/d/msgid/aprsfi/9f48f112-2aea-45b2-9bea-e9df788a332bn%40googlegroups.com is a good list of ICOM models, and all are via dstar

Built atop / assumes #50 has been merged and/or replaces it.